### PR TITLE
Show locale switcher when using multilocale editor

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -195,13 +195,19 @@ class Plugin extends PluginBase
         function useWysiwyg($form)
         {
             $replacable = [
-                'codeeditor', 'Eein\Wysiwyg\FormWidgets\Trumbowyg', 'richeditor', 'RainLab\Blog\FormWidgets\BlogMarkdown', 'RainLab\Blog\FormWidgets\MLBlogMarkdown', 'mlricheditor'
+                'codeeditor', 'Eein\Wysiwyg\FormWidgets\Trumbowyg', 'richeditor', 'RainLab\Blog\FormWidgets\BlogMarkdown',
+                'RainLab\Blog\FormWidgets\MLBlogMarkdown', 'mlricheditor',
+            ];
+
+			$multilanguage = [
+                'RainLab\Blog\FormWidgets\MLBlogMarkdown', 'mlricheditor',
             ];
 
             foreach ($form->getFields() as $field) {
                 if (!empty($field->config['type']) && in_array($field->config['type'], $replacable)) {
                     if (Settings::instance()->editor == 'richeditor') {
-                        $field->config['type'] = $field->config['widget'] = 'richeditor';
+                    	$editor = in_array($field->config['type'], $multilanguage) ? 'mlricheditor' : 'richeditor';
+                        $field->config['type'] = $field->config['widget'] = $editor;
                     } else {
                         $field->config['type'] = $field->config['widget'] = 'AnandPatel\WysiwygEditors\FormWidgets\Editor';
                     }


### PR DESCRIPTION
When using RainLab.Tranlate and multilocale editor, we should show locale switcher.

![snimek obrazovky 2016-09-12 v 10 09 14](https://cloud.githubusercontent.com/assets/374917/18428942/0ed4154e-78d1-11e6-98be-59fd47026a21.png)

Please make also October market update.
